### PR TITLE
Add getrf method

### DIFF
--- a/src/pinverse.f90
+++ b/src/pinverse.f90
@@ -22,7 +22,7 @@
          !===============================================================================
          !> author: Seyed Ali Ghasemi
          !> Calculates the pseudoinverse of a matrix A.
-         pure function pinv_rel(A, method, tol) result(Apinv)
+         function pinv_rel(A, method, tol) result(Apinv)
 
             ! Inputs:
             real(rk),     dimension(:, :), contiguous, intent(in) :: A
@@ -37,6 +37,8 @@
                select case (method)
                 case('gesvd','gesdd')
                   Apinv = pinvSVD_rel(A, method, tol)
+                case('getrf')
+                  Apinv = pinvLU_rel(A)
                 case default
                   error stop 'method is not valid.'
                end select
@@ -90,5 +92,122 @@
 
          end function pinvSVD_rel
          !===============================================================================
+
+
+         !===============================================================================
+         !> author: ZUO Zhihua
+         !> Calculates the pseudoinverse of a matrix A using the LU decomposition.
+         function pinvLU_rel(A) result(Apinv)
+
+            ! Inputs:
+            real(rk), dimension(:, :), intent(in)              :: A     ! Input matrix A
+
+            ! Outputs:
+            real(rk), dimension(size(A,2), size(A,1))          :: Apinv ! Pseudoinverse of A
+
+            ! Local variables
+
+            if (size(A, 1) == size(A, 2)) then
+               Apinv = invLU_rel(A)
+            elseif (size(A, 1) > size(A, 2)) then
+               Apinv = transpose(A)
+               Apinv = gemm(invLU_rel(gemm(Apinv, A)), Apinv)
+            else
+               Apinv = transpose(A)
+               Apinv = gemm(Apinv, invLU_rel(gemm(A, Apinv)))
+            end if
+
+         end function pinvLU_rel
+         !===============================================================================
+
+
+         !===============================================================================
+         !> author: ZUO Zhihua
+         !> Calculates the inverse of a matrix A using the LU decomposition.
+         function invLU_rel(A) result(Ainv)
+
+            ! Inputs:
+            real(rk), dimension(:, :), intent(in)              :: A     ! Input matrix A
+
+            ! Outputs:
+            real(rk), dimension(size(A,2), size(A,1))          :: Ainv  ! Inverse of A
+
+            ! Local variables
+            integer                                            :: ipiv(size(A, 1)), info
+            real(rk)                                           :: work(size(A, 2))
+
+            ! External subroutine for calculating the inverse of a matrix A using the LU decomposition.
+            interface
+               subroutine dgetrf(m, n, a, lda, ipiv, info)
+                  import rk
+                  integer, intent(in) :: m
+                  integer, intent(in) :: n
+                  integer, intent(in) :: lda
+                  integer, intent(out) :: ipiv(*)
+                  integer, intent(out) :: info
+                  real(rk), intent(inout) :: a(lda, *)
+               end subroutine dgetrf
+               subroutine dgetri(n, a, lda, ipiv, work, lwork, info)
+                  import rk
+                  integer, intent(in) :: n
+                  integer, intent(in) :: lda
+                  integer, intent(in) :: lwork
+                  integer, intent(out) :: ipiv(*)
+                  integer, intent(out) :: info
+                  real(rk), intent(inout) :: a(lda, *)
+                  real(rk), intent(out) :: work(*)
+               end subroutine dgetri
+            end interface
+
+            Ainv = A
+            call dgetrf(size(A, 1), size(A, 2), Ainv, size(A, 1), ipiv, info)
+            call dgetri(size(A, 2), Ainv, size(A, 1), ipiv, work, size(A, 2), info)
+
+         end function invLU_rel
+         !===============================================================================
+
+
+         !===============================================================================
+         !> author: ZUO Zhihua
+         !> Calculates the matrix-matrix product of two matrices A and B.
+         pure function gemm(A, B) result(C)
+
+            ! Inputs:
+            real(rk), dimension(:, :), intent(in)              :: A     ! Input matrix A
+            real(rk), dimension(:, :), intent(in)              :: B     ! Input matrix B
+
+            ! Outputs:
+            real(rk), dimension(size(A,1), size(B,2))          :: C     ! Matrix-matrix product of A and B
+
+            ! Local variables
+            integer                                            :: m, n, k
+
+            ! External subroutine for calculating the matrix-matrix product of two matrices A and B.
+            interface
+               pure subroutine dgemm(transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+                  import rk
+                  integer, intent(in) :: ldc
+                  integer, intent(in) :: ldb
+                  integer, intent(in) :: lda
+                  character, intent(in) :: transa
+                  character, intent(in) :: transb
+                  integer, intent(in) :: m
+                  integer, intent(in) :: n
+                  integer, intent(in) :: k
+                  real(rk), intent(in) :: alpha
+                  real(rk), intent(in) :: a(lda, *)
+                  real(rk), intent(in) :: b(ldb, *)
+                  real(rk), intent(in) :: beta
+                  real(rk), intent(inout) :: c(ldc, *)
+               end subroutine dgemm
+            end interface
+
+            m = size(A, 1)
+            n = size(B, 2)
+            k = size(A, 2)
+
+            call dgemm('N', 'N', m, n, k, 1.0_rk, A, m, B, k, 0.0_rk, C, m)
+
+         end function gemm
 
       end module pinverse

--- a/test/test3.f90
+++ b/test/test3.f90
@@ -13,8 +13,8 @@ program test3
   integer                               :: m, n     ! Define variables for matrix dimensions
   type(timer)                           :: w        ! Define a watchtype object for timing measurements
 
-  m = 10000                   ! Set the number of rows for matrix A
-  n = 1000                    ! Set the number of columns for matrix A
+  m = 2000                    ! Set the number of rows for matrix A
+  n = 200                     ! Set the number of columns for matrix A
   allocate(A(m,n))            ! Allocate memory for matrix A
   call random_number(A)       ! Fill matrix A with random numbers between 0 and 1
 
@@ -22,9 +22,36 @@ program test3
 
   Ainv = pinv(A*10)          ! Calculate the matrix inverse of A using the 'pinv' function
 
-  call timer_stop(w,message=' Elapsed time:')
+  call timer_stop(w,message=' Elapsed time (2000*200 , gesvd):')
 
-  deallocate(Ainv)           ! Deallocate memory for matrix Ainv
+  call timer_start(w)
+
+  Ainv = pinv(A*10, method='getrf')          ! Calculate the matrix inverse of A using the 'pinv' function and the getrf method
+
+  call timer_stop(w,message=' Elapsed time (2000*200 , getrf):')
+
+  deallocate(Ainv)            ! Deallocate memory for matrix Ainv
+  deallocate(A)               ! Deallocate memory for matrix A
+
+  m = 2000                    ! Set the number of rows for matrix A
+  n = 1800                    ! Set the number of columns for matrix A
+  allocate(A(m,n))            ! Allocate memory for matrix A
+  call random_number(A)       ! Fill matrix A with random numbers between 0 and 1
+
+  call timer_start(w)
+
+  Ainv = pinv(A*10)           ! Calculate the matrix inverse of A using the 'pinv' function
+
+  call timer_stop(w,message=' Elapsed time (2000*1800, gesvd):')
+
+  call timer_start(w)
+
+  Ainv = pinv(A*10, method='getrf')          ! Calculate the matrix inverse of A using the 'pinv' function and the getrf method
+
+  call timer_stop(w,message=' Elapsed time (2000*1800, getrf):')
+
+  deallocate(Ainv)            ! Deallocate memory for matrix Ainv
+  deallocate(A)               ! Deallocate memory for matrix A
 
   print *, "Test 3 passed."
 


### PR DESCRIPTION
## Description
After testing, the pseudo-inverse matrices obtained based on LU decomposition and SVD decomposition are different.

ChatGPT told me that:
> The pseudo-inverse matrix obtained by LU decomposition is usually dense; the pseudo-inverse matrix obtained by SVD decomposition is usually sparse.
In general, the pseudo-inverse matrix obtained by SVD decomposition is more accurate, especially when the original matrix is close to the singular matrix, and SVD decomposition is more stable and reliable. However, the computational complexity of using SVD decomposition is higher, so in the actual operation, a suitable decomposition method needs to be selected to meet different requirements and constraints.

I'm not good at linear algebra, feedback is welcome @gha3mi .

## Benchmark

I only have a Windows OS environment (MSYS2-GFortran 12.2 and OneAPI 2023.0.0, **AMD R5 2500U** with Radeon Vega Mobile Gfx 2.00 GHz):

```sh
> fpm test --compiler ifort --flag "/Qmkl=parallel /heap-arrays:0" test3 --profile release
 Elapsed time (2000*200 , gesvd):  0.243 [s]
 Elapsed time (2000*200 , getrf):  0.026 [s]
 Elapsed time (2000*1800, gesvd): 40.315 [s]
 Elapsed time (2000*1800, getrf):  2.825 [s]
 Test 3 passed.
> fpm test --compiler gfortran --flag "-Wno-line-truncation -llapack -lblas" test3 --profile release
 Elapsed time (2000*200 , gesvd):  0.281 [s]
 Elapsed time (2000*200 , getrf):  0.047 [s]
 Elapsed time (2000*1800, gesvd): 90.453 [s]
 Elapsed time (2000*1800, getrf):  2.375 [s]
 Test 3 passed.
```